### PR TITLE
Add full description for Rock Paper app

### DIFF
--- a/subghz/plugins/rock_paper_scissors/.flipcorg/README.md
+++ b/subghz/plugins/rock_paper_scissors/.flipcorg/README.md
@@ -1,0 +1,14 @@
+This is a multiplayer adaptation of the classic rock-paper-scissors game—you need at least two devices to play the game.
+
+Select "Host game" from the Main menu to allow your opponent to connect using the "Join game" option. Once the Sub-Ghz connection is established, you can start the battle.
+
+On your Flipper Zero, press the OK button twice and then press one of three buttons:
+
+- The Up button to select a rock.
+- The Right button to select paper.
+- The Down button to select scissors.
+
+Rock beats scissors, scissors beat paper, and paper beats rock.
+
+Wins and losses stats are available in the app, as well as the ability to change your name for games.
+

--- a/subghz/plugins/rock_paper_scissors/application.fam
+++ b/subghz/plugins/rock_paper_scissors/application.fam
@@ -5,12 +5,12 @@ App(
     entry_point="rock_paper_scissors_app",
     requires=["gui", "subghz"],
     stack_size=2 * 1024,
-    fap_version=(1, 3),
+    fap_version=(1, 4),
     fap_icon="rock_paper_scissors.png",
     fap_icon_assets="images",
     fap_icon_assets_symbol="rock_paper_scissors",
     fap_category="Games",
     fap_author="jamisonderek",
-    fap_description="Play rock paper scissors with your friends using the Flipper Zero SubGHz radio!",
+    fap_description="Play the rock-paper-scissors game with your friends using the Flipper Zero Sub-GHz radio!",
     fap_weburl="https://github.com/jamisonderek/flipper-zero-tutorials/blob/main/subghz/plugins/rock_paper_scissors/README.md"    
 )


### PR DESCRIPTION
Right now, the Rock Paper game doesn't have a full description for the catalog. This PR adds a full description for the game

For visible changes, also need changes to the main catalog repository:
- In [description section](https://github.com/flipperdevices/flipper-application-catalog/blob/main/applications/Games/rock_paper_scissors/manifest.yml#L7) replace this:
```
description: "Play rock paper scissors with your friends using the Flipper Zero SubGHz radio!"
```
to this:
```
description: "@./.flipcorg/README.md"
```
- In [changelog section](https://github.com/flipperdevices/flipper-application-catalog/blob/main/applications/Games/rock_paper_scissors/manifest.yml#L8C1-L8C10) replace this:
```
changelog: "v1.3 - More robust radio communication\nv1.2 - Updated subghz API"
```
to this:
```
changelog: "v1.4 - Update description\nv1.3 - More robust radio communication\nv1.2 - Updated subghz API"
```