### PR TITLE
Automatically turn on connected HID reader when starting read functions

### DIFF
--- a/gpio/wiegand/scenes/wiegand_read.c
+++ b/gpio/wiegand/scenes/wiegand_read.c
@@ -49,6 +49,7 @@ void wiegand_start_read(void *context)
     App *app = context;
     data_saved = false;
     bit_count = 0;
+    furi_hal_power_enable_otg();
     furi_hal_gpio_init_simple(pinD0, GpioModeInterruptRiseFall);
     furi_hal_gpio_init_simple(pinD1, GpioModeInterruptRiseFall);
     furi_hal_gpio_add_int_callback(pinD0, wiegand_isr_d0, NULL);

--- a/gpio/wiegand/scenes/wiegand_scan.c
+++ b/gpio/wiegand/scenes/wiegand_scan.c
@@ -51,6 +51,7 @@ static void wiegand_start_scan(void *context)
     UNUSED(context);
     data_saved = false;
     bit_count = 0;
+    furi_hal_power_enable_otg();
     furi_hal_gpio_init_simple(pinD0, GpioModeInterruptRiseFall);
     furi_hal_gpio_init_simple(pinD1, GpioModeInterruptRiseFall);
     furi_hal_gpio_add_int_callback(pinD0, wiegand_scan_isr_d0, NULL);


### PR DESCRIPTION
# What's new

-  Automatically turn on connected HID reader connected to GPIO 5v power when starting read functions

# QA test plan 

- Hook up HID reader to 5v power on GPIO
- Launch read function > reader should power on 
- Launch scan w/autosave function > reader should power on
- Manually turn off GPIO power in GPIO menu prior to testing both read functions 